### PR TITLE
PrefDataStoreクラスの追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 
@@ -37,6 +37,8 @@ dependencies {
     implementation(libs.material)
     implementation(libs.activity)
     implementation(libs.constraintlayout)
+    implementation(libs.datastore.preferences.core.jvm)
+    implementation(libs.datastore.preferences.rxjava3)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/app/src/main/java/com/example/mobileappdev/Gist.java
+++ b/app/src/main/java/com/example/mobileappdev/Gist.java
@@ -1,0 +1,11 @@
+package com.example.mobileappdev;
+
+import java.util.Map;
+
+public class Gist {
+    public Map<String,GistFile> files;
+    public static class GistFile{
+        public String content;
+
+    }
+}

--- a/app/src/main/java/com/example/mobileappdev/PrefDataStore.java
+++ b/app/src/main/java/com/example/mobileappdev/PrefDataStore.java
@@ -1,0 +1,61 @@
+package com.example.mobileappdev;
+
+import android.content.Context;
+
+import androidx.datastore.preferences.core.Preferences;
+import androidx.datastore.preferences.core.PreferencesKeys;
+import androidx.datastore.preferences.rxjava3.RxPreferenceDataStoreBuilder;
+import androidx.datastore.rxjava3.RxDataStore;
+
+import java.util.Optional;
+
+import io.reactivex.rxjava3.core.Single;
+
+
+public class PrefDataStore {
+    private static PrefDataStore instance;
+    private final RxDataStore<Preferences> dataStore;
+
+    private PrefDataStore(RxDataStore<Preferences> dataStore) {
+        this.dataStore = dataStore;
+    }
+
+
+    public static PrefDataStore getInstance(Context context) {
+        if (instance == null) {
+            var dataStore = new RxPreferenceDataStoreBuilder(context.getApplicationContext(), "settings"
+            ).build();
+            instance = new PrefDataStore(dataStore);
+        }
+        return instance;
+    }
+
+    public void setString(String key, String value) {
+        dataStore.updateDataAsync(prefsIn -> {
+                    var mutablePreferences = prefsIn.toMutablePreferences();
+                    var prefKey = PreferencesKeys.stringKey(key);
+
+
+                    mutablePreferences.set(prefKey, value);
+                    return Single.just(mutablePreferences);
+                })
+                .subscribe();
+    }
+    public Optional<String> getString(String key) {
+        return dataStore.data()
+                .map(prefs -> {
+                    var prefKey = PreferencesKeys.stringKey(key);
+
+
+
+                    return Optional.ofNullable(prefs.get(prefKey));
+
+
+
+                })
+                .blockingFirst();
+    }
+
+}
+
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ appcompat = "1.7.0"
 material = "1.12.0"
 activity = "1.9.2"
 constraintlayout = "2.1.4"
+datastorePreferencesCoreJvm = "1.1.1"
+datastorePreferencesRxjava3 = "1.1.1"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -16,6 +18,8 @@ appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "a
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+datastore-preferences-core-jvm = { group = "androidx.datastore", name = "datastore-preferences-core-jvm", version.ref = "datastorePreferencesCoreJvm" }
+datastore-preferences-rxjava3 = { group = "androidx.datastore", name = "datastore-preferences-rxjava3", version.ref = "datastorePreferencesRxjava3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# 変更点
reference DataStoreを用いてデータ保存を行うためのクラス，PrefDataStoreを追加
# 注意
Javaのバージョンを11へと上げている．これは #1 と重複する．